### PR TITLE
Fix function name on docs: perform_ocr_batch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,13 +70,13 @@ Perform OCR on mupltiple images:
 
 .. code-block:: python
 
-    app.perform_batch_ocr(['image_1.png', 'image_2.png', 'image_3.png'])
+    app.perform_ocr_batch(['image_1.png', 'image_2.png', 'image_3.png'])
 
 Perform OCR on multiple images using multiple workers (:code:`multiprocessing`):
 
 .. code-block:: python
 
-    app.perform_batch_ocr(['image_1.png', 'image_3.png', 'image_2.png'], workers=2)
+    app.perform_ocr_batch(['image_1.png', 'image_3.png', 'image_2.png'], workers=2)
 
 
 Using Command Line Interface

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -23,13 +23,13 @@ Perform OCR on mupltiple images:
 
 .. code-block:: python
 
-    app.perform_batch_ocr(['image_1.png', 'image_2.png', 'image_3.png'])
+    app.perform_ocr_batch(['image_1.png', 'image_2.png', 'image_3.png'])
 
 Perform OCR on multiple images using multiple workers (:code:`multiprocessing`):
 
 .. code-block:: python
 
-    app.perform_batch_ocr(['image_1.png', 'image_3.png', 'image_2.png'], workers=2)
+    app.perform_ocr_batch(['image_1.png', 'image_3.png', 'image_2.png'], workers=2)
 
 
 Using Command Line Interface


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When I read the docs to use the library I got some problems with function name. ```'GoogleOCRApplication' object has no attribute 'perform_batch_ocr```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I just read the library code and saw that, actually the function name is ```perform_ocr_batch```.
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I just changed my function naming call and the problem was fixed. It was just a doc outdated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

